### PR TITLE
FEATURE: Metadata extraction from resources

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,7 +1,7 @@
 Options -MultiViews
 Options +FollowSymLinks
 RewriteEngine on
-RewriteBase /~benel/steatite/
+RewriteBase /Steatite
 
 RewriteRule ^thumbnail/(.+)/(\d+)\+(\d+)\+(\d+)\+(\d+)$ controller/thumbnail.php?id=$1&x1=$2&y1=$3&x2=$4&y2=$5
 RewriteRule ^thumbnail/(.+)$ controller/thumbnail.php?id=$1

--- a/controller/corpus.php
+++ b/controller/corpus.php
@@ -18,6 +18,7 @@ http://www.gnu.org/licenses/agpl.html
 */
 
 include('../lib/Mustache.php');
+include('../metadata.php');
 
 preg_match('#(.+)/corpus/#', $_SERVER['REQUEST_URI'], $path);
 $data = array(
@@ -31,11 +32,18 @@ $query = $db->prepare(
   ."WHERE a1.source_id=a2.source_id AND a1.attribute_name='name' "
   ."AND a2.attribute_name='corpus' AND a2.attribute_value=?"
 );
+
 $query->execute(array($_GET['corpus']));
 while ($row = $query->fetch()) {
+  $source = "../picture/" . $row[0];
+
+  $metadata = Metadata::getMetadata($source);
+
   $data['pictures'][] = array(
     'item' => $row[0],
-    'name' => $row[1]
+    'name' => $row[1],
+    'created' => $metadata['created'],
+    'spatial' => $metadata['spatial']
   );
 }
 $renderer = new Mustache();

--- a/controller/item.php
+++ b/controller/item.php
@@ -18,6 +18,7 @@ http://www.gnu.org/licenses/agpl.html
 */
 
 include('../lib/Mustache.php');
+include('../metadata.php');
 
 $db = new PDO('sqlite:../attribute/database');
 $query = $db->prepare(
@@ -27,12 +28,22 @@ $query = $db->prepare(
 $query->execute(array($_GET['item']));
 $result = $query->fetch();
 preg_match('#(.+)/item/#', $_SERVER['REQUEST_URI'], $path);
+
+$source = "../picture/" . $_GET['item'];
+
+$metadata = Metadata::getMetadata($source);
+
 $data = array(
   'corpus' => $_GET['corpus'],
   'item' => $_GET['item'],
   'service' => 'http://'.$_SERVER['HTTP_HOST'].$path[1], //TODO port
-  'name' => $result[0]
+  'name' => $result[0],
+  'created' => $metadata['created'],
+  'spatial' => $metadata['spatial']
 );
+
+	
+
 $renderer = new Mustache();
 header('content-type: application/json');
 echo $renderer->render(file_get_contents('../view/item.json'), $data);

--- a/metadata.php
+++ b/metadata.php
@@ -1,0 +1,62 @@
+<?php
+
+class Metadata {
+
+	/**
+	 * Extracted TAGS from metadata associated with DublinCore namespace standards
+	 */
+	private static $_TAGS = array(
+		"DateTimeOriginal" 	=> "created",
+		"GPSPosition" 		=> "spatial"
+	);
+
+	/**
+	 * exiftool options
+	 */
+	private static $_OPTIONS = array(
+		"d %Y-%m-%d",
+		"q",
+		"php"
+	);
+
+	public static function getMetadata($resource) {
+		$cmd = "exiftool";
+
+		// Put needed TAG
+		foreach(self::$_TAGS as $tag => $value) {
+			$cmd .= " -" . $tag;
+		}
+
+		// Put needed options
+		foreach(self::$_OPTIONS as $opt) {
+			$cmd .= " -" . $opt;
+		}
+
+		$cmd .= " " . $resource;
+
+		eval('$metadata=' . `$cmd`);
+
+		return self::conformResponse($metadata[0]);
+	}
+
+	/**
+	 * Change keys name in order to be conform with DublinCore metadata namespace
+	 */
+	private static function conformResponse($res) {
+		foreach ($res as $key => $value) {
+			if(!empty($value) && array_key_exists($key, self::$_TAGS)) {
+				$res[self::$_TAGS[$key]] = $res[$key];
+			}
+
+			// Unset all unused data
+			unset($res[$key]);
+		}
+
+		return $res;
+	}
+
+}
+
+
+
+?>

--- a/view/corpus.json
+++ b/view/corpus.json
@@ -8,7 +8,7 @@
     {"key":["{{{corpus}}}", "{{item}}"], "value":{"created":"{{{created}}}"}}
     {{/created}}
     {{#spatial}},
-    {"key":["{{{corpus}}}", "{{item}}"], "value":{"spatial":"{{{spatial}}}"}}
+    {"key":["{{{corpus}}}", "{{item}}"], "value":{"spatial":"{{spatial}}"}}
     {{/spatial}}
   {{/pictures}}
 ]}

--- a/view/corpus.json
+++ b/view/corpus.json
@@ -8,7 +8,7 @@
     {"key":["{{{corpus}}}", "{{item}}"], "value":{"created":"{{{created}}}"}}
     {{/created}}
     {{#spatial}},
-	{"key":["{{{corpus}}}", "{{item}}"], "value":{"spatial":"{{{spatial}}}"}}
+    {"key":["{{{corpus}}}", "{{item}}"], "value":{"spatial":"{{{spatial}}}"}}
     {{/spatial}}
   {{/pictures}}
 ]}

--- a/view/corpus.json
+++ b/view/corpus.json
@@ -4,5 +4,11 @@
     {"key":["{{{corpus}}}", "{{item}}"], "value":{"name":"{{{name}}}"}},
     {"key":["{{{corpus}}}", "{{item}}"], "value":{"resource":"{{service}}/picture/{{item}}"}},
     {"key":["{{{corpus}}}", "{{item}}"], "value":{"thumbnail":"{{service}}/thumbnail/{{item}}"}}
+    {{#created}},
+    {"key":["{{{corpus}}}", "{{item}}"], "value":{"created":"{{{created}}}"}}
+    {{/created}}
+    {{#spatial}},
+	{"key":["{{{corpus}}}", "{{item}}"], "value":{"spatial":"{{{spatial}}}"}}
+    {{/spatial}}
   {{/pictures}}
 ]}

--- a/view/item.json
+++ b/view/item.json
@@ -2,4 +2,10 @@
     {"key":["{{{corpus}}}", "{{item}}"], "value":{"name":"{{{name}}}"}},
     {"key":["{{{corpus}}}", "{{item}}"], "value":{"resource":"{{service}}/picture/{{item}}"}},
     {"key":["{{{corpus}}}", "{{item}}"], "value":{"thumbnail":"{{service}}/thumbnail/{{item}}"}}
+    {{#created}},
+    {"key":["{{{corpus}}}", "{{item}}"], "value":{"created":"{{{created}}}"}}
+    {{/created}}
+    {{#spatial}},
+	{"key":["{{{corpus}}}", "{{item}}"], "value":{"spatial":"{{{spatial}}}"}}
+    {{/spatial}}
 ]}

--- a/view/item.json
+++ b/view/item.json
@@ -6,6 +6,6 @@
     {"key":["{{{corpus}}}", "{{item}}"], "value":{"created":"{{{created}}}"}}
     {{/created}}
     {{#spatial}},
-	{"key":["{{{corpus}}}", "{{item}}"], "value":{"spatial":"{{{spatial}}}"}}
+	{"key":["{{{corpus}}}", "{{item}}"], "value":{"spatial":"{{spatial}}"}}
     {{/spatial}}
 ]}


### PR DESCRIPTION
As you suggested in ticket #8 I renamed the field "date" to "created" and the field "coverage" to "spatial".

Those namespaces respect the [DublinCore standards](http://dublincore.org/documents/2012/06/14/dcmi-terms/).

Also, I structured the metadata class in order to be editable. A developper can set options and tags easily by changing two static arrays.

This feature closes #8 #1 